### PR TITLE
Fix typo + improve sentences

### DIFF
--- a/src/components/HelpIcon.tsx
+++ b/src/components/HelpIcon.tsx
@@ -40,7 +40,7 @@ export const HelpIcon: FC = () => {
               <TableRow>
                 <TableCell>Heading</TableCell>
                 <TableCell>
-                  <code># </code> at the biggining of a line
+                  <code># </code> at the beginning of a line
                   <br />
                   support 3 levels.
                 </TableCell>
@@ -48,7 +48,7 @@ export const HelpIcon: FC = () => {
               <TableRow>
                 <TableCell>Bullet List</TableCell>
                 <TableCell>
-                  <code>* </code>, <code>- </code> at the biggining of a line
+                  <code>* </code>, <code>- </code> at the beginning of a line
                 </TableCell>
               </TableRow>
               <TableRow>

--- a/src/components/HelpIcon.tsx
+++ b/src/components/HelpIcon.tsx
@@ -40,15 +40,15 @@ export const HelpIcon: FC = () => {
               <TableRow>
                 <TableCell>Heading</TableCell>
                 <TableCell>
-                  <code># </code> at the beginning of a line
+                  Hit <code>#</code> and space key at the beginning of a line.
                   <br />
-                  support 3 levels.
+                  Supports up to 3 levels.
                 </TableCell>
               </TableRow>
               <TableRow>
                 <TableCell>Bullet List</TableCell>
                 <TableCell>
-                  <code>* </code>, <code>- </code> at the beginning of a line
+                  Hit <code>*</code> or <code>-</code> and space key at the beginning of a line.
                 </TableCell>
               </TableRow>
               <TableRow>
@@ -57,7 +57,7 @@ export const HelpIcon: FC = () => {
               </TableRow>
               <TableRow>
                 <TableCell>Link</TableCell>
-                <TableCell>Select text and Paste link</TableCell>
+                <TableCell>Select text and paste a link.</TableCell>
               </TableRow>
             </TableBody>
           </Table>


### PR DESCRIPTION
Thanks for the useful tool,

I've fixed the typo in e660a5c and improved the sentences in e762110.
This is because the original help text like `# ` has a space next to `#` but I struggled to understand how to put headers and bullets. The space key is now explicitly described.

Please tell me if you don't need the improvement. I'll then remove the commit and force-push the branch.

Thank you.